### PR TITLE
Install mount.nfs helper

### DIFF
--- a/openstack/examples/idr-dundee-nfs.yml
+++ b/openstack/examples/idr-dundee-nfs.yml
@@ -14,6 +14,13 @@
 
   tasks:
 
+  - name: Install NFS mount utility
+    become: yes
+    yum:
+      name: nfs-utils
+      state: present
+    when: not use_samba
+
   # Do not create mountpoint using file, the mount module will create it
   # automatically. This avoids problems where the module tries to change
   # permissions on an existing directory


### PR DESCRIPTION
`/usr/sbin/mount.nfs` is already present on Centos 7 cloud images, but may not be included on manual/bare-metal installations. Ideally this should go into a role somewhere, for now I've just added it to the playbook.
